### PR TITLE
Add original LICENSE for templated lambda

### DIFF
--- a/lambda/LICENSE-MIT
+++ b/lambda/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Joe Turgeon (@arithmetric)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,0 +1,3 @@
+The lambda is a templated version of [aws-lambda-ses-forwarder](https://github.com/arithmetric/aws-lambda-ses-forwarder/blob/master/index.js) by [@arithmetric](https://github.com/arithmetric).
+
+Included in this directory is the original MIT license.


### PR DESCRIPTION
As stated by the Apache license FAQ:

> Basically, you can do whatever you want with a software licensed under the MIT license – just make sure that you add a copy of the original MIT license and copyright notice to it. The Apache License is also a permissive license.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
