### PR TITLE
Fix dependency issue ses <-> lambda

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -43,7 +43,8 @@ jobs:
     name: tfsec
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@master
-      - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+      - name: Terraform pr commenter
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.0.2
+        with:
+          tfsec_args: --concise-output
+          github_token: ${{ github.token }}

--- a/lambda.tf
+++ b/lambda.tf
@@ -71,6 +71,6 @@ resource "aws_lambda_permission" "allow_ses" {
   action         = "lambda:InvokeFunction"
   function_name  = module.lambda.name
   principal      = "ses.amazonaws.com"
-  source_arn     = aws_ses_receipt_rule.default.arn
+  source_arn     = "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:receipt-rule-set/${aws_ses_receipt_rule_set.default.rule_set_name}:receipt-rule/*"
   source_account = data.aws_caller_identity.current.account_id
 }


### PR DESCRIPTION
- `aws_ses_receipt_rule.default` needs the lambda ARN to be able to specify the lambda action. But the `aws_lambda_permission.allow_ses` required the ARN of the `aws_ses_receipt_rule`. This creates a circular dependency. This change changes the depends from the `receipt_rule` to the `receipt_rule_set`, solving this dependency. The result is a slightly more open lambda permission. It can now trigger all receipt rules in the receipt rule set, but since the `receipt_rule_set` is only used for the email alias functionality in reality these permissions do not differ. 