### PR TITLE
bug: Fix incoming mail rule when catching all mail for a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ module "ses-forwarder" {
 }
 ```
 
+To match all email addresses on a domain, use a key without the name part of an email address before the "at" symbol:
+
+```terraform
+module "ses-forwarder" {
+  ...
+  recipient_mapping = {
+    "@app.dev" = ["user1@company.io", "user2@company.io"]
+  }
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,12 @@
 locals {
   bucket_prefix = length(regexall("/$", var.bucket_prefix)) > 0 ? var.bucket_prefix : "${var.bucket_prefix}/"
+
+  # Remove prefixed @ if present in key name. The lambda catches all mail for a domain when it sees
+  # the prefix but the incoming mail rule in SES breaks when it's present, so we strip it out for
+  # the incoming mail rule.
+  recipient_mapping = {
+    for k, v in var.recipient_mapping : startswith(k, "@") ? trimprefix(k, "@") : k => v
+  }
 }
 
 data "aws_caller_identity" "current" {}
@@ -17,7 +24,7 @@ resource "aws_ses_active_receipt_rule_set" "default" {
 resource "aws_ses_receipt_rule" "default" {
   name          = var.ses_rule_name
   rule_set_name = aws_ses_active_receipt_rule_set.default.rule_set_name
-  recipients    = keys(var.recipient_mapping)
+  recipients    = keys(local.recipient_mapping)
   enabled       = true
   scan_enabled  = true
 


### PR DESCRIPTION
The lambda expects a key prefixed with `@` to catch mail for a domain but this breaks the SES incoming mail rule, as it wants just the domain name. This change keeps the behaviour of using a domain prefixed with `@` and strips the character when creating the incoming mail rule.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
