### PR TITLE
bugfix: nodejs20 support

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var AWS = require('aws-sdk');
+const { S3Client, CopyObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
+const { SESv2Client, SendEmailCommand } = require("@aws-sdk/client-sesv2");
 
 console.log("AWS Lambda SES Forwarder // @arithmetric // Version 5.1.0");
 
@@ -36,16 +37,16 @@ console.log("AWS Lambda SES Forwarder // @arithmetric // Version 5.1.0");
 //
 //   To match all email addresses matching no other mapping, use "@" as a key.
 var defaultConfig = {
-  fromEmail: "${from_email}",
-  subjectPrefix: "${subject_prefix}",
-  emailBucket: "${bucket_name}",
-  emailKeyPrefix: "${bucket_prefix}",
-  allowPlusSign: ${allow_plus_sign},
-  forwardMapping: ${recipient_mapping}
+  fromEmail: process.env.FROM_EMAIL,
+  subjectPrefix: process.env.SUBJECT_PREFIX,
+  emailBucket: process.env.BUCKET_NAME,
+  emailKeyPrefix: process.env.BUCKET_PREFIX,
+  allowPlusSign: process.env.ALLOW_PLUS_SIGN === 'true',
+  forwardMapping: JSON.parse(process.env.RECIPIENT_MAPPING)
 };
 
 /**
- * Parses the SES event record provided for the `mail` and `receipients` data.
+ * Parses the SES event record provided for the `mail` and `recipients` data.
  *
  * @param {object} data - Data bundle with context, email, etc.
  *
@@ -54,11 +55,11 @@ var defaultConfig = {
 exports.parseEvent = function (data) {
   // Validate characteristics of a SES event record.
   if (!data.event ||
-      !data.event.hasOwnProperty('Records') ||
-      data.event.Records.length !== 1 ||
-      !data.event.Records[0].hasOwnProperty('eventSource') ||
-      data.event.Records[0].eventSource !== 'aws:ses' ||
-      data.event.Records[0].eventVersion !== '1.0') {
+    !data.event.hasOwnProperty('Records') ||
+    data.event.Records.length !== 1 ||
+    !data.event.Records[0].hasOwnProperty('eventSource') ||
+    data.event.Records[0].eventSource !== 'aws:ses' ||
+    data.event.Records[0].eventVersion !== '1.0') {
     data.log({
       message: "parseEvent() received invalid SES message:",
       level: "error", event: JSON.stringify(data.event)
@@ -101,7 +102,7 @@ exports.transformRecipients = function (data) {
         origEmailUser = origEmailKey.slice(0, pos);
       }
       if (origEmailDomain &&
-          data.config.forwardMapping.hasOwnProperty(origEmailDomain)) {
+        data.config.forwardMapping.hasOwnProperty(origEmailDomain)) {
         newRecipients = newRecipients.concat(
           data.config.forwardMapping[origEmailDomain]);
         data.originalRecipient = origEmail;
@@ -146,7 +147,7 @@ exports.fetchMessage = function (data) {
       data.config.emailKeyPrefix + data.email.messageId
   });
   return new Promise(function (resolve, reject) {
-    data.s3.copyObject({
+    data.s3.send(new CopyObjectCommand({
       Bucket: data.config.emailBucket,
       CopySource: data.config.emailBucket + '/' + data.config.emailKeyPrefix +
         data.email.messageId,
@@ -154,11 +155,11 @@ exports.fetchMessage = function (data) {
       ACL: 'private',
       ContentType: 'text/plain',
       StorageClass: 'STANDARD'
-    }, function (err) {
+    }), function (err) {
       if (err) {
         data.log({
           level: "error",
-          message: "copyObject() returned error:",
+          message: "CopyObjectCommand() returned error:",
           error: err,
           stack: err.stack
         });
@@ -167,21 +168,21 @@ exports.fetchMessage = function (data) {
       }
 
       // Load the raw email from S3
-      data.s3.getObject({
+      data.s3.send(new GetObjectCommand({
         Bucket: data.config.emailBucket,
         Key: data.config.emailKeyPrefix + data.email.messageId
-      }, function (err, result) {
+      }), async function (err, result) {
         if (err) {
           data.log({
             level: "error",
-            message: "getObject() returned error:",
+            message: "GetObjectCommand() returned error:",
             error: err,
             stack: err.stack
           });
           return reject(
             new Error("Error: Failed to load message body from S3."));
         }
-        data.emailData = result.Body.toString();
+        data.emailData = await result.Body.transformToString();
         return resolve(data);
       });
     });
@@ -229,10 +230,10 @@ exports.processMessage = function (data) {
       var fromText;
       if (data.config.fromEmail) {
         fromText = 'From: ' + from.replace(/<(.*)>/, '').trim() +
-        ' <' + data.config.fromEmail + '>';
+          ' <' + data.config.fromEmail + '>';
       } else {
         fromText = 'From: ' + from.replace('<', 'at ').replace('>', '') +
-        ' <' + data.originalRecipient + '>';
+          ' <' + data.originalRecipient + '>';
       }
       return fromText;
     });
@@ -271,7 +272,7 @@ exports.processMessage = function (data) {
 };
 
 /**
- * Send email using the SES sendRawEmail command.
+ * Send email using the SESv2 SendEmailCommand command.
  *
  * @param {object} data - Data bundle with context, email, etc.
  *
@@ -279,11 +280,8 @@ exports.processMessage = function (data) {
  */
 exports.sendMessage = function (data) {
   var params = {
-    Destinations: data.recipients,
-    Source: data.originalRecipient,
-    RawMessage: {
-      Data: data.emailData
-    }
+    Destination: { ToAddresses: data.recipients },
+    Content: { Raw: { Data: Buffer.from(data.emailData) } },
   };
   data.log({
     level: "info",
@@ -292,11 +290,11 @@ exports.sendMessage = function (data) {
       data.recipients.join(", ") + "."
   });
   return new Promise(function (resolve, reject) {
-    data.ses.sendRawEmail(params, function (err, result) {
+    data.ses.send(new SendEmailCommand(params), function (err, result) {
       if (err) {
         data.log({
           level: "error",
-          message: "sendRawEmail() returned error.",
+          message: "SendEmailCommand() returned error.",
           error: err,
           stack: err.stack
         });
@@ -304,7 +302,7 @@ exports.sendMessage = function (data) {
       }
       data.log({
         level: "info",
-        message: "sendRawEmail() successful.",
+        message: "SendEmailCommand() successful.",
         result: result
       });
       resolve(data);
@@ -337,9 +335,9 @@ exports.handler = function (event, context, callback, overrides) {
     context: context,
     config: overrides && overrides.config ? overrides.config : defaultConfig,
     log: overrides && overrides.log ? overrides.log : console.log,
-    ses: overrides && overrides.ses ? overrides.ses : new AWS.SES(),
+    ses: overrides && overrides.ses ? overrides.ses : new SESv2Client(),
     s3: overrides && overrides.s3 ?
-      overrides.s3 : new AWS.S3({ signatureVersion: 'v4' })
+      overrides.s3 : new S3Client({ signatureVersion: 'v4' })
   };
   Promise.series(steps, data)
     .then(function (data) {


### PR DESCRIPTION
This PR updates the aws-lambda-ses-forwarder to work with Node.js 20, since the code was broken on the newer runtime.

What's Changed:
- Updated outdated dependencies that were causing issues with the new runtime.
- Made sure the Lambda function works smoothly with Node.js 20 on AWS.
- Remove the TF template file and relied on env variables from the code.

Testing:
- Deployed to AWS Lambda (Node.js 20) and manually tested email forwarding via SES events.

Since the repo hasn't been updated in a while, it might be worth forking if this is a critical part of our stack!