### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,23 +69,23 @@ module "ses-forwarder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | schubergphilis/mcaf-s3/aws | ~> 0.14.1 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
 
 ## Resources
 
@@ -96,10 +96,10 @@ module "ses-forwarder" {
 | [aws_ses_receipt_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_receipt_rule) | resource |
 | [aws_ses_receipt_rule_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_receipt_rule_set) | resource |
 | [archive_file.lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -109,10 +109,11 @@ module "ses-forwarder" {
 | <a name="input_from_email"></a> [from\_email](#input\_from\_email) | Forwarded emails will come from this verified address | `string` | n/a | yes |
 | <a name="input_recipient_mapping"></a> [recipient\_mapping](#input\_recipient\_mapping) | Map of recipients and the addresses to forward on to | `map(any)` | n/a | yes |
 | <a name="input_allow_plus_sign"></a> [allow\_plus\_sign](#input\_allow\_plus\_sign) | Enables support for plus sign suffixes on email addresses | `bool` | `true` | no |
-| <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | S3 bucket lifecycle rules | `list(any)` | <pre>[<br>  {<br>    "enabled": true,<br>    "expiration": {<br>      "days": 14<br>    },<br>    "id": "two-week-retention",<br>    "noncurrent_version_expiration": {<br>      "noncurrent_days": 14<br>    }<br>  }<br>]</pre> | no |
+| <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | S3 bucket lifecycle rules | `list(any)` | <pre>[<br/>  {<br/>    "enabled": true,<br/>    "expiration": {<br/>      "days": 14<br/>    },<br/>    "id": "two-week-retention",<br/>    "noncurrent_version_expiration": {<br/>      "noncurrent_days": 14<br/>    }<br/>  }<br/>]</pre> | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | S3 key name prefix where SES stores email | `string` | `"inbound-mail"` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN used for encryption | `string` | `null` | no |
 | <a name="input_lambda_name"></a> [lambda\_name](#input\_lambda\_name) | The name of the Lambda function | `string` | `"EmailForwarder"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where the resources will be created. If omitted, the default provider region is used. | `string` | `null` | no |
 | <a name="input_ses_rule_name"></a> [ses\_rule\_name](#input\_ses\_rule\_name) | The name of the SES rule that invokes the Lambda function | `string` | `"EmailForwarder"` | no |
 | <a name="input_ses_rule_set_name"></a> [ses\_rule\_set\_name](#input\_ses\_rule\_set\_name) | The name of the active Rule Set in SES which you have already configured | `string` | `"EmailForwarder"` | no |
 | <a name="input_subject_prefix"></a> [subject\_prefix](#input\_subject\_prefix) | String to prepend to the subject of forwarded mail | `string` | `""` | no |

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.4.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/lambda.tf
+++ b/lambda.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "lambda_policy" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.lambda_name}:*",
+      "arn:aws:logs:${local.account_region}:${local.account_id}:log-group:/aws/lambda/${var.lambda_name}:*",
     ]
   }
 
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "lambda_policy" {
 
     resources = [
       "arn:aws:s3:::${var.bucket_name}/*",
-      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*",
+      "arn:aws:ses:${local.account_region}:${local.account_id}:identity/*",
     ]
   }
 
@@ -56,19 +56,23 @@ data "archive_file" "lambda" {
 module "lambda" {
   #checkov:skip=CKV_AWS_272: This module does not provide support for code-signing
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
+  region           = local.account_region
   description      = "Forwards email sent to recipients in the \"${var.ses_rule_set_name}\" SES Rule Set to external addresses"
   filename         = data.archive_file.lambda.output_path
   handler          = "index.handler"
   kms_key_arn      = var.kms_key_arn
   memory_size      = 256
   name             = var.lambda_name
-  policy           = data.aws_iam_policy_document.lambda_policy.json
   runtime          = "nodejs20.x"
   source_code_hash = data.archive_file.lambda.output_base64sha256
   tags             = var.tags
   timeout          = 30
+
+  execution_role = {
+    policy = data.aws_iam_policy_document.lambda_policy.json
+  }
 
   environment = {
     ALLOW_PLUS_SIGN   = var.allow_plus_sign
@@ -81,10 +85,11 @@ module "lambda" {
 }
 
 resource "aws_lambda_permission" "allow_ses" {
+  region         = local.account_region
   statement_id   = "GiveSESPermissionToInvokeFunction"
   action         = "lambda:InvokeFunction"
   function_name  = module.lambda.name
   principal      = "ses.amazonaws.com"
-  source_arn     = "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:receipt-rule-set/${aws_ses_receipt_rule_set.default.rule_set_name}:receipt-rule/*"
-  source_account = data.aws_caller_identity.current.account_id
+  source_arn     = "arn:aws:ses:${local.account_region}:${local.account_id}:receipt-rule-set/${aws_ses_receipt_rule_set.default.rule_set_name}:receipt-rule/*"
+  source_account = local.account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 locals {
-  bucket_prefix = length(regexall("/$", var.bucket_prefix)) > 0 ? var.bucket_prefix : "${var.bucket_prefix}/"
+  account_id     = data.aws_caller_identity.default.account_id
+  account_region = var.region != null ? var.region : data.aws_region.default.region
+  bucket_prefix  = length(regexall("/$", var.bucket_prefix)) > 0 ? var.bucket_prefix : "${var.bucket_prefix}/"
 
   # Remove prefixed @ if present in key name. The lambda catches all mail for a domain when it sees
   # the prefix but the incoming mail rule in SES breaks when it's present, so we strip it out for
@@ -9,19 +11,22 @@ locals {
   }
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "default" {}
 
-data "aws_region" "current" {}
+data "aws_region" "default" {}
 
 resource "aws_ses_receipt_rule_set" "default" {
+  region        = local.account_region
   rule_set_name = var.ses_rule_set_name
 }
 
 resource "aws_ses_active_receipt_rule_set" "default" {
+  region        = local.account_region
   rule_set_name = aws_ses_receipt_rule_set.default.rule_set_name
 }
 
 resource "aws_ses_receipt_rule" "default" {
+  region        = local.account_region
   name          = var.ses_rule_name
   rule_set_name = aws_ses_active_receipt_rule_set.default.rule_set_name
   recipients    = keys(local.recipient_mapping)

--- a/s3.tf
+++ b/s3.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "logs_bucket" {
     condition {
       test     = "StringEquals"
       variable = "aws:Referer"
-      values   = [data.aws_caller_identity.current.account_id]
+      values   = [local.account_id]
     }
   }
 }
@@ -22,12 +22,12 @@ module "s3_bucket" {
   #checkov:skip=CKV_AWS_19: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module supports encryption with KMS.
   #checkov:skip=CKV_AWS_145: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module support encryption with KMS.
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 0.14.1"
+  version = "~> 2.0.0"
 
+  region         = local.account_region
   name           = var.bucket_name
   kms_key_arn    = var.kms_key_arn
   lifecycle_rule = var.bucket_lifecycle_rules
   policy         = data.aws_iam_policy_document.logs_bucket.json
-  versioning     = true
   tags           = var.tags
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.4.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "recipient_mapping" {
   description = "Map of recipients and the addresses to forward on to"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the resources will be created. If omitted, the default provider region is used."
+}
+
 variable "ses_rule_name" {
   type        = string
   default     = "EmailForwarder"


### PR DESCRIPTION
⚠️ This introduces a breaking change as it requires at least v6 of the AWS provider. ⚠️

🛠️ Summary

This pull request updates all resources to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all resources, which improves multi-region compatibility and control. 

Region configuration improvements:
- Added a new region variable in variables.tf to allow users to specify the AWS region for the bucket and related resources. If omitted, the default provider region is used. All resources and submodules have been updated to use this variable.
- Solve deprecations (the aws_region data source now needs to be references via `region` and not `name`).

🚀 Motivation
Adding var.region removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.