### PR TITLE
feature: using latest Node.js 24.x runtime for emailforwarder lambda & add DLQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ module "ses-forwarder" {
 | [aws_ses_active_receipt_rule_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_active_receipt_rule_set) | resource |
 | [aws_ses_receipt_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_receipt_rule) | resource |
 | [aws_ses_receipt_rule_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_receipt_rule_set) | resource |
+| [aws_sqs_queue.lambda_dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [archive_file.lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/lambda.tf
+++ b/lambda.tf
@@ -65,7 +65,7 @@ module "lambda" {
   kms_key_arn      = var.kms_key_arn
   memory_size      = 256
   name             = var.lambda_name
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   source_code_hash = data.archive_file.lambda.output_base64sha256
   tags             = var.tags
   timeout          = 30

--- a/lambda.tf
+++ b/lambda.tf
@@ -2,6 +2,14 @@ locals {
   kms_key_arn_provided = var.kms_key_arn != null ? ["allow_kms"] : []
 }
 
+resource "aws_sqs_queue" "lambda_dlq" {
+  name                              = "${var.lambda_name}-dlq"
+  kms_data_key_reuse_period_seconds = var.kms_key_arn != null ? 300 : null
+  kms_master_key_id                 = var.kms_key_arn
+  message_retention_seconds         = 1209600 # 14 days
+  tags                              = var.tags
+}
+
 data "aws_iam_policy_document" "lambda_policy" {
   statement {
     sid = "AllowLogManagement"
@@ -20,13 +28,24 @@ data "aws_iam_policy_document" "lambda_policy" {
     sid = "AllowBucketAccessAndSendingEmail"
     actions = [
       "s3:GetObject",
-      "s3:PutObject",
-      "ses:SendRawEmail"
+      "ses:SendRawEmail",
+      "ses:SendEmail"
     ]
 
     resources = [
       "arn:aws:s3:::${var.bucket_name}/*",
       "arn:aws:ses:${local.account_region}:${local.account_id}:identity/*",
+    ]
+  }
+
+  statement {
+    sid = "AllowDLQAccess"
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.lambda_dlq.arn
     ]
   }
 
@@ -58,17 +77,18 @@ module "lambda" {
   source  = "schubergphilis/mcaf-lambda/aws"
   version = "~> 3.0.0"
 
-  region           = local.account_region
-  description      = "Forwards email sent to recipients in the \"${var.ses_rule_set_name}\" SES Rule Set to external addresses"
-  filename         = data.archive_file.lambda.output_path
-  handler          = "index.handler"
-  kms_key_arn      = var.kms_key_arn
-  memory_size      = 256
-  name             = var.lambda_name
-  runtime          = "nodejs24.x"
-  source_code_hash = data.archive_file.lambda.output_base64sha256
-  tags             = var.tags
-  timeout          = 30
+  region                 = local.account_region
+  dead_letter_target_arn = aws_sqs_queue.lambda_dlq.arn
+  description            = "Forwards email sent to recipients in the \"${var.ses_rule_set_name}\" SES Rule Set to external addresses"
+  filename               = data.archive_file.lambda.output_path
+  handler                = "index.handler"
+  kms_key_arn            = var.kms_key_arn
+  memory_size            = 256
+  name                   = var.lambda_name
+  runtime                = "nodejs24.x"
+  source_code_hash       = data.archive_file.lambda.output_base64sha256
+  tags                   = var.tags
+  timeout                = 30
 
   execution_role = {
     policy = data.aws_iam_policy_document.lambda_policy.json

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const { S3Client, CopyObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
 const { SESv2Client, SendEmailCommand } = require("@aws-sdk/client-sesv2");
 
-console.log("AWS Lambda SES Forwarder // @arithmetric // Version 5.1.0");
+console.log("AWS Lambda SES Forwarder // based on: @arithmetric // Version 6.0.0");
 
 // Configure the S3 bucket and key prefix for stored raw emails, and the
 // mapping of email addresses to forward from and to.
@@ -55,9 +55,9 @@ var defaultConfig = {
 exports.parseEvent = function (data) {
   // Validate characteristics of a SES event record.
   if (!data.event ||
-    !data.event.hasOwnProperty('Records') ||
+    !Object.hasOwn(data.event, 'Records') ||
     data.event.Records.length !== 1 ||
-    !data.event.Records[0].hasOwnProperty('eventSource') ||
+    !Object.hasOwn(data.event.Records[0], 'eventSource') ||
     data.event.Records[0].eventSource !== 'aws:ses' ||
     data.event.Records[0].eventVersion !== '1.0') {
     data.log({
@@ -87,7 +87,7 @@ exports.transformRecipients = function (data) {
     if (data.config.allowPlusSign) {
       origEmailKey = origEmailKey.replace(/\+.*?@/, '@');
     }
-    if (data.config.forwardMapping.hasOwnProperty(origEmailKey)) {
+    if (Object.hasOwn(data.config.forwardMapping, origEmailKey)) {
       newRecipients = newRecipients.concat(
         data.config.forwardMapping[origEmailKey]);
       data.originalRecipient = origEmail;
@@ -102,16 +102,16 @@ exports.transformRecipients = function (data) {
         origEmailUser = origEmailKey.slice(0, pos);
       }
       if (origEmailDomain &&
-        data.config.forwardMapping.hasOwnProperty(origEmailDomain)) {
+        Object.hasOwn(data.config.forwardMapping, origEmailDomain)) {
         newRecipients = newRecipients.concat(
           data.config.forwardMapping[origEmailDomain]);
         data.originalRecipient = origEmail;
       } else if (origEmailUser &&
-        data.config.forwardMapping.hasOwnProperty(origEmailUser)) {
+        Object.hasOwn(data.config.forwardMapping, origEmailUser)) {
         newRecipients = newRecipients.concat(
           data.config.forwardMapping[origEmailUser]);
         data.originalRecipient = origEmail;
-      } else if (data.config.forwardMapping.hasOwnProperty("@")) {
+      } else if (Object.hasOwn(data.config.forwardMapping, "@")) {
         newRecipients = newRecipients.concat(
           data.config.forwardMapping["@"]);
         data.originalRecipient = origEmail;
@@ -140,49 +140,55 @@ exports.transformRecipients = function (data) {
  * @return {object} - Promise resolved with data.
  */
 exports.fetchMessage = async function (data) {
-  // Copying email object to ensure read permission
+  const maxRetries = 3;
+  const retryDelay = 1000; // 1 second
+
   data.log({
     level: "info",
     message: "Fetching email at s3://" + data.config.emailBucket + '/' +
       data.config.emailKeyPrefix + data.email.messageId
   });
 
-  try {
-    await data.s3.send(new CopyObjectCommand({
-      Bucket: data.config.emailBucket,
-      CopySource: data.config.emailBucket + '/' + data.config.emailKeyPrefix +
-        data.email.messageId,
-      Key: data.config.emailKeyPrefix + data.email.messageId,
-      ACL: 'private',
-      ContentType: 'text/plain',
-      StorageClass: 'STANDARD'
-    }));
-  } catch (err) {
-    data.log({
-      level: "error",
-      message: "CopyObjectCommand() returned error:",
-      error: err,
-      stack: err.stack
-    });
-    throw new Error("Error: Could not make readable copy of email.");
-  }
+  // Load the raw email from S3 with retry logic for race condition
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await data.s3.send(new GetObjectCommand({
+        Bucket: data.config.emailBucket,
+        Key: `${data.config.emailKeyPrefix}${data.email.messageId}`
+      }));
+      data.emailData = await result.Body.transformToString();
 
-  // Load the raw email from S3
-  try {
-    const result = await data.s3.send(new GetObjectCommand({
-      Bucket: data.config.emailBucket,
-      Key: data.config.emailKeyPrefix + data.email.messageId
-    }));
-    data.emailData = await result.Body.transformToString();
-    return data;
-  } catch (err) {
-    data.log({
-      level: "error",
-      message: "GetObjectCommand() returned error:",
-      error: err,
-      stack: err.stack
-    });
-    throw new Error("Error: Failed to load message body from S3.");
+      if (attempt > 1) {
+        data.log({
+          level: "info",
+          message: `Successfully fetched message on attempt ${attempt}`
+        });
+      }
+
+      return data;
+    } catch (err) {
+      const isNotFound = err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404;
+      const isLastAttempt = attempt === maxRetries;
+
+      if (isNotFound && !isLastAttempt) {
+        data.log({
+          level: "warn",
+          message: `Object not found on attempt ${attempt}/${maxRetries}, retrying in ${retryDelay}ms...`
+        });
+        await new Promise(resolve => setTimeout(resolve, retryDelay));
+        continue;
+      }
+
+      data.log({
+        level: "error",
+        message: "Failed to load message body from S3",
+        error: err.message,
+        errorName: err.name,
+        stack: err.stack,
+        attempts: attempt
+      });
+      throw new Error("Failed to load message body from S3");
+    }
   }
 };
 
@@ -198,6 +204,31 @@ exports.processMessage = function (data) {
   var match = data.emailData.match(/^((?:.+\r?\n)*)(\r?\n(?:.*\s+)*)/m);
   var header = match && match[1] ? match[1] : data.emailData;
   var body = match && match[2] ? match[2] : '';
+
+  // Extract and log metadata for audit trail
+  var fromMatch = header.match(/^from:[\t ]?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
+  var subjectMatch = header.match(/^subject:[\t ]?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
+  var messageIdMatch = header.match(/^message-id:[\t ]?(<.*?>)/mi);
+
+  var originalFrom = fromMatch && fromMatch[1] ? fromMatch[1].replace(/\r?\n\s+/g, ' ').trim() : 'unknown';
+  var originalSubject = subjectMatch && subjectMatch[1] ? subjectMatch[1].replace(/\r?\n\s+/g, ' ').trim() : 'no subject';
+  var originalMessageId = messageIdMatch && messageIdMatch[1] ? messageIdMatch[1] : data.email.messageId;
+
+  data.log({
+    level: "info",
+    message: "Processing email",
+    originalFrom: originalFrom,
+    originalSubject: originalSubject,
+    originalMessageId: originalMessageId,
+    sesMessageId: data.email.messageId
+  });
+
+  // Store metadata for later logging
+  data.emailMetadata = {
+    originalFrom: originalFrom,
+    originalSubject: originalSubject,
+    originalMessageId: originalMessageId
+  };
 
   // Add "Reply-To:" with the "From" address if it doesn't already exists
   if (!/^reply-to:[\t ]?/mi.test(header)) {
@@ -277,32 +308,40 @@ exports.processMessage = function (data) {
  */
 exports.sendMessage = async function (data) {
   var params = {
+    FromEmailAddress: data.config.fromEmail,
     Destination: { ToAddresses: data.recipients },
     Content: { Raw: { Data: Buffer.from(data.emailData) } },
   };
   data.log({
     level: "info",
-    message: "sendMessage: Sending email via SES. Original recipients: " +
-      data.originalRecipients.join(", ") + ". Transformed recipients: " +
-      data.recipients.join(", ") + "."
+    message: "Sending email via SES",
+    originalFrom: data.emailMetadata ? data.emailMetadata.originalFrom : 'unknown',
+    originalSubject: data.emailMetadata ? data.emailMetadata.originalSubject : 'unknown',
+    originalMessageId: data.emailMetadata ? data.emailMetadata.originalMessageId : 'unknown',
+    originalRecipients: data.originalRecipients.join(", "),
+    forwardingTo: data.recipients.join(", ")
   });
 
   try {
     const result = await data.ses.send(new SendEmailCommand(params));
     data.log({
       level: "info",
-      message: "SendEmailCommand() successful.",
-      result: result
+      message: "Email sent successfully",
+      originalFrom: data.emailMetadata ? data.emailMetadata.originalFrom : 'unknown',
+      originalSubject: data.emailMetadata ? data.emailMetadata.originalSubject : 'unknown',
+      messageId: result.MessageId
     });
     return data;
   } catch (err) {
     data.log({
       level: "error",
-      message: "SendEmailCommand() returned error.",
-      error: err,
+      message: "Email sending failed",
+      originalFrom: data.emailMetadata ? data.emailMetadata.originalFrom : 'unknown',
+      originalSubject: data.emailMetadata ? data.emailMetadata.originalSubject : 'unknown',
+      error: err.message,
       stack: err.stack
     });
-    throw new Error('Error: Email sending failed.');
+    throw new Error('Email sending failed');
   }
 };
 
@@ -316,6 +355,7 @@ exports.sendMessage = async function (data) {
 exports.handler = async function (event, context) {
   // Support overrides through context for testing purposes
   var overrides = context && context.overrides ? context.overrides : undefined;
+
   var steps = overrides && overrides.steps ? overrides.steps :
     [
       exports.parseEvent,
@@ -324,49 +364,53 @@ exports.handler = async function (event, context) {
       exports.processMessage,
       exports.sendMessage
     ];
+
   var data = {
     event: event,
     context: context,
     config: overrides && overrides.config ? overrides.config : defaultConfig,
     log: overrides && overrides.log ? overrides.log : console.log,
     ses: overrides && overrides.ses ? overrides.ses : new SESv2Client(),
-    s3: overrides && overrides.s3 ?
-      overrides.s3 : new S3Client({ signatureVersion: 'v4' })
+    s3: overrides && overrides.s3 ? overrides.s3 : new S3Client()
   };
-  try {
-    const result = await Promise.series(steps, data);
-    if (result === null) {
-      // No recipients found, processing stopped early
-      return;
-    }
-    data.log({
-      level: "info",
-      message: "Process finished successfully."
-    });
-  } catch (err) {
-    data.log({
-      level: "error",
-      message: "Step returned error: " + err.message,
-      error: err,
-      stack: err.stack
-    });
-    throw new Error("Error: Step returned error.");
-  }
-};
 
-Promise.series = function (promises, initValue) {
-  return promises.reduce(function (chain, promise) {
-    if (typeof promise !== 'function') {
-      return chain.then(() => {
-        throw new Error("Error: Invalid promise item: " + promise);
+  try {
+    for (const step of steps) {
+      if (typeof step !== "function") {
+        throw new Error("Error: Invalid step item: " + step);
+      }
+
+      data = await step(data);
+
+      // Allow transformRecipients (or any step) to short-circuit cleanly.
+      if (data === null || (data && data._skip)) {
+        break;
+      }
+    }
+
+    // Successful completion: return void
+    if (data && data.log) {
+      data.log({
+        level: "info",
+        message: data && data._skip
+          ? "Process finished successfully (skipped: no matching recipients)."
+          : (data === null
+              ? "Process finished successfully (skipped: no matching recipients)."
+              : "Process finished successfully.")
       });
     }
-    return chain.then(function(result) {
-      // Stop processing if result is null (no recipients case)
-      if (result === null) {
-        return null;
-      }
-      return promise(result);
-    });
-  }, Promise.resolve(initValue));
+
+    return;
+  } catch (err) {
+    if (data && data.log) {
+      data.log({
+        level: "error",
+        message: "Step returned error: " + (err && err.message ? err.message : String(err)),
+        error: err,
+        stack: err && err.stack
+      });
+    }
+    // Propagate original error so the invocation is marked as failed.
+    throw err;
+  }
 };

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -125,7 +125,7 @@ exports.transformRecipients = function (data) {
         "original destinations: " + data.originalRecipients.join(", "),
       level: "info"
     });
-    return data.callback();
+    return Promise.resolve(null);
   }
 
   data.recipients = newRecipients;
@@ -139,15 +139,16 @@ exports.transformRecipients = function (data) {
  *
  * @return {object} - Promise resolved with data.
  */
-exports.fetchMessage = function (data) {
+exports.fetchMessage = async function (data) {
   // Copying email object to ensure read permission
   data.log({
     level: "info",
     message: "Fetching email at s3://" + data.config.emailBucket + '/' +
       data.config.emailKeyPrefix + data.email.messageId
   });
-  return new Promise(function (resolve, reject) {
-    data.s3.send(new CopyObjectCommand({
+
+  try {
+    await data.s3.send(new CopyObjectCommand({
       Bucket: data.config.emailBucket,
       CopySource: data.config.emailBucket + '/' + data.config.emailKeyPrefix +
         data.email.messageId,
@@ -155,38 +156,34 @@ exports.fetchMessage = function (data) {
       ACL: 'private',
       ContentType: 'text/plain',
       StorageClass: 'STANDARD'
-    }), function (err) {
-      if (err) {
-        data.log({
-          level: "error",
-          message: "CopyObjectCommand() returned error:",
-          error: err,
-          stack: err.stack
-        });
-        return reject(
-          new Error("Error: Could not make readable copy of email."));
-      }
-
-      // Load the raw email from S3
-      data.s3.send(new GetObjectCommand({
-        Bucket: data.config.emailBucket,
-        Key: data.config.emailKeyPrefix + data.email.messageId
-      }), async function (err, result) {
-        if (err) {
-          data.log({
-            level: "error",
-            message: "GetObjectCommand() returned error:",
-            error: err,
-            stack: err.stack
-          });
-          return reject(
-            new Error("Error: Failed to load message body from S3."));
-        }
-        data.emailData = await result.Body.transformToString();
-        return resolve(data);
-      });
+    }));
+  } catch (err) {
+    data.log({
+      level: "error",
+      message: "CopyObjectCommand() returned error:",
+      error: err,
+      stack: err.stack
     });
-  });
+    throw new Error("Error: Could not make readable copy of email.");
+  }
+
+  // Load the raw email from S3
+  try {
+    const result = await data.s3.send(new GetObjectCommand({
+      Bucket: data.config.emailBucket,
+      Key: data.config.emailKeyPrefix + data.email.messageId
+    }));
+    data.emailData = await result.Body.transformToString();
+    return data;
+  } catch (err) {
+    data.log({
+      level: "error",
+      message: "GetObjectCommand() returned error:",
+      error: err,
+      stack: err.stack
+    });
+    throw new Error("Error: Failed to load message body from S3.");
+  }
 };
 
 /**
@@ -278,7 +275,7 @@ exports.processMessage = function (data) {
  *
  * @return {object} - Promise resolved with data.
  */
-exports.sendMessage = function (data) {
+exports.sendMessage = async function (data) {
   var params = {
     Destination: { ToAddresses: data.recipients },
     Content: { Raw: { Data: Buffer.from(data.emailData) } },
@@ -289,25 +286,24 @@ exports.sendMessage = function (data) {
       data.originalRecipients.join(", ") + ". Transformed recipients: " +
       data.recipients.join(", ") + "."
   });
-  return new Promise(function (resolve, reject) {
-    data.ses.send(new SendEmailCommand(params), function (err, result) {
-      if (err) {
-        data.log({
-          level: "error",
-          message: "SendEmailCommand() returned error.",
-          error: err,
-          stack: err.stack
-        });
-        return reject(new Error('Error: Email sending failed.'));
-      }
-      data.log({
-        level: "info",
-        message: "SendEmailCommand() successful.",
-        result: result
-      });
-      resolve(data);
+
+  try {
+    const result = await data.ses.send(new SendEmailCommand(params));
+    data.log({
+      level: "info",
+      message: "SendEmailCommand() successful.",
+      result: result
     });
-  });
+    return data;
+  } catch (err) {
+    data.log({
+      level: "error",
+      message: "SendEmailCommand() returned error.",
+      error: err,
+      stack: err.stack
+    });
+    throw new Error('Error: Email sending failed.');
+  }
 };
 
 /**
@@ -316,11 +312,10 @@ exports.sendMessage = function (data) {
  *
  * @param {object} event - Lambda event from inbound email received by AWS SES.
  * @param {object} context - Lambda context object.
- * @param {object} callback - Lambda callback object.
- * @param {object} overrides - Overrides for the default data, including the
- * configuration, SES object, and S3 object.
  */
-exports.handler = function (event, context, callback, overrides) {
+exports.handler = async function (event, context) {
+  // Support overrides through context for testing purposes
+  var overrides = context && context.overrides ? context.overrides : undefined;
   var steps = overrides && overrides.steps ? overrides.steps :
     [
       exports.parseEvent,
@@ -331,7 +326,6 @@ exports.handler = function (event, context, callback, overrides) {
     ];
   var data = {
     event: event,
-    callback: callback,
     context: context,
     config: overrides && overrides.config ? overrides.config : defaultConfig,
     log: overrides && overrides.log ? overrides.log : console.log,
@@ -339,23 +333,25 @@ exports.handler = function (event, context, callback, overrides) {
     s3: overrides && overrides.s3 ?
       overrides.s3 : new S3Client({ signatureVersion: 'v4' })
   };
-  Promise.series(steps, data)
-    .then(function (data) {
-      data.log({
-        level: "info",
-        message: "Process finished successfully."
-      });
-      return data.callback();
-    })
-    .catch(function (err) {
-      data.log({
-        level: "error",
-        message: "Step returned error: " + err.message,
-        error: err,
-        stack: err.stack
-      });
-      return data.callback(new Error("Error: Step returned error."));
+  try {
+    const result = await Promise.series(steps, data);
+    if (result === null) {
+      // No recipients found, processing stopped early
+      return;
+    }
+    data.log({
+      level: "info",
+      message: "Process finished successfully."
     });
+  } catch (err) {
+    data.log({
+      level: "error",
+      message: "Step returned error: " + err.message,
+      error: err,
+      stack: err.stack
+    });
+    throw new Error("Error: Step returned error.");
+  }
 };
 
 Promise.series = function (promises, initValue) {
@@ -365,6 +361,12 @@ Promise.series = function (promises, initValue) {
         throw new Error("Error: Invalid promise item: " + promise);
       });
     }
-    return chain.then(promise);
+    return chain.then(function(result) {
+      // Stop processing if result is null (no recipients case)
+      if (result === null) {
+        return null;
+      }
+      return promise(result);
+    });
   }, Promise.resolve(initValue));
 };


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Updated the lambda to work with Node.js 24.x

## :rocket: Motivation

Lifecycle maintenance. The script needed to be updated because of this error:

    "errorType": "Runtime.CallbackHandlerDeprecated",
    "errorMessage": "ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html.",


