### PR TITLE
fix: Set create policy to true for execution role

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -91,6 +91,7 @@ module "lambda" {
   timeout                = 30
 
   execution_role = {
+    create_policy = true
     policy = data.aws_iam_policy_document.lambda_policy.json
   }
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -92,7 +92,7 @@ module "lambda" {
 
   execution_role = {
     create_policy = true
-    policy = data.aws_iam_policy_document.lambda_policy.json
+    policy        = data.aws_iam_policy_document.lambda_policy.json
   }
 
   environment = {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Fix count error when KMS key ARN is passed to the SES forwarder module by explicitly setting create_policy = true in the lambda execution role configuration.

## :rocket: Motivation

When using this module with a KMS key, Terraform fails during plan with:

  Error: Invalid count argument
  The "count" value depends on resource attributes that cannot be determined until apply


## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
